### PR TITLE
[Fix] Groups Visibility For All Members

### DIFF
--- a/app/repositories/groups_pg_repository_impl.py
+++ b/app/repositories/groups_pg_repository_impl.py
@@ -6,11 +6,12 @@ using SQLAlchemy ORM for database operations with async session.
 
 import uuid
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.models import GroupModel
+from app.models.group_members_model import GroupMemberModel
 from app.repositories.interfaces.groups_repository_interface import GroupRepositoryInterface
 from app.utils.logger_util import get_logger
 
@@ -77,6 +78,8 @@ class GroupPGRepository(GroupRepositoryInterface):
     async def get_all_groups(self, user_id: uuid.UUID, offset: int, limit: int) -> list[GroupModel]:  # noqa: D417
         """Retrieve a list of all groups for a user.
 
+        This includes groups created by the user and groups where the user is a member.
+
         Args:
             user_id (uuid.UUID): The ID of the user whose groups to retrieve.
 
@@ -87,7 +90,21 @@ class GroupPGRepository(GroupRepositoryInterface):
             NoResultFound: If no groups are found for the user.
 
         """
-        query = select(GroupModel).where(GroupModel.created_by == user_id).offset(offset).limit(limit)
+        # Query to get groups where user is creator OR a member
+        query = (
+            select(GroupModel)
+            .outerjoin(GroupMemberModel, GroupModel.id == GroupMemberModel.group_id)
+            .where(
+                or_(
+                    GroupModel.created_by == user_id,
+                    GroupMemberModel.user_id == user_id,
+                ),
+            )
+            .distinct()
+            .offset(offset)
+            .limit(limit)
+        )
+
         get_logger().debug("Retrieving groups for user ID: %s, offset: %s, limit: %s", user_id, offset, limit)
         result = await self.session.execute(query)
         return list(result.scalars().all())
@@ -117,6 +134,8 @@ class GroupPGRepository(GroupRepositoryInterface):
     async def count_groups(self, user_id: uuid.UUID) -> int:
         """Count the number of groups for a user.
 
+        This includes groups created by the user and groups where the user is a member.
+
         Args:
             user_id (uuid.UUID): The ID of the user whose groups to count.
 
@@ -124,7 +143,17 @@ class GroupPGRepository(GroupRepositoryInterface):
             int: The number of groups associated with the user.
 
         """
-        query = select(func.count()).select_from(GroupModel).where(GroupModel.created_by == user_id)
+        query = (
+            select(func.count(func.distinct(GroupModel.id)))
+            .select_from(GroupModel)
+            .outerjoin(GroupMemberModel, GroupModel.id == GroupMemberModel.group_id)
+            .where(
+                or_(
+                    GroupModel.created_by == user_id,
+                    GroupMemberModel.user_id == user_id,
+                ),
+            )
+        )
         result = await self.session.execute(query)
         return result.scalar_one() or 0
 

--- a/tests/test_system_groups.py
+++ b/tests/test_system_groups.py
@@ -431,3 +431,73 @@ class TestGroupAPI:
         assert pagination["limit"] == 10
         assert pagination["total"] == 1
         assert pagination["pages"] == 1
+
+    @pytest.mark.asyncio
+    async def test_group_visibility_for_members(
+        self,
+        client: AsyncClient,
+        auth_token_header: dict,
+    ) -> None:
+        """Test that both group creator and group members can see the group in their lists."""
+        # Create a group with the first user (admin)
+        group_data = GroupModel(
+            id=uuid.uuid4(),
+            name="Shared Test Group",
+            description="A group visible to both creator and members",
+            created_by=uuid.uuid4(),
+        )
+        create_response = await self._create_group(client, auth_token_header, group_data)
+        assert create_response.status_code == status.HTTP_200_OK
+        group_id = create_response.json()["data"]["group"]["id"]
+
+        # Register a second user
+        second_user_data = {
+            "email": "seconduser@example.com",
+            "username": "Second User",
+            "password": "password123",
+        }
+        register_response = await client.post("/users/register", json=second_user_data)
+        assert register_response.status_code == status.HTTP_200_OK
+
+        # Login as second user to get their auth token
+        login_response = await client.post(
+            "/users/login",
+            json={
+                "email": second_user_data["email"],
+                "password": second_user_data["password"],
+            },
+        )
+        assert login_response.status_code == status.HTTP_200_OK
+        second_user_token = login_response.json()["data"]["token"]
+        second_user_headers = {"Authorization": f"Bearer {second_user_token}"}
+
+        # Add second user to the group (using admin token)
+        add_member_response = await client.post(
+            f"/groups/{group_id}/members",
+            headers=auth_token_header,
+            json=GroupMemberAddRequest(
+                email=second_user_data["email"],
+                role="Member",
+            ).model_dump(),
+        )
+        assert add_member_response.status_code == status.HTTP_200_OK
+
+        # Verify first user (admin/creator) can see the group in their list
+        admin_groups_response = await client.get("/groups", headers=auth_token_header)
+        assert admin_groups_response.status_code == status.HTTP_200_OK
+        admin_groups = admin_groups_response.json()["data"]["groups"]
+        assert len(admin_groups) == 1
+        assert admin_groups[0]["id"] == group_id
+        assert admin_groups[0]["name"] == group_data.name
+
+        # Verify second user (member) can see the group in their list
+        member_groups_response = await client.get("/groups", headers=second_user_headers)
+        assert member_groups_response.status_code == status.HTTP_200_OK
+        member_groups = member_groups_response.json()["data"]["groups"]
+        assert len(member_groups) == 1
+        assert member_groups[0]["id"] == group_id
+        assert member_groups[0]["name"] == group_data.name
+
+        # Verify both users see the same group with correct member count
+        assert admin_groups[0]["member_count"] == 2
+        assert member_groups[0]["member_count"] == 2


### PR DESCRIPTION
### Summary
Fixed an issue where certain users were unable to see all the groups they are members of. This ensures consistent group visibility across the platform for all valid members.

### Changes
- Updated group visibility logic to include all members, not just the owner.
- Added test cases to cover various visibility scenarios.

### Checklist
- [x] Tests added/updated
- [ ] Documentation updated
