### PR TITLE
[Fix] Remove Member Raise Fix

### DIFF
--- a/app/interfaces/api/v1/controllers/group_controller.py
+++ b/app/interfaces/api/v1/controllers/group_controller.py
@@ -374,7 +374,6 @@ async def update_member_role(
 async def remove_group_member(
     group_id: uuid.UUID,
     user_id: uuid.UUID,
-    current_user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
     group_service: Annotated[GroupService, Depends(get_group_service)],
     _: Annotated[None, Depends(verify_user_admin_role)],
 ) -> None:
@@ -396,7 +395,7 @@ async def remove_group_member(
 
     """
     try:
-        await group_service.remove_member(group_id, user_id, current_user_id)
+        await group_service.remove_member(group_id, user_id)
     except ApplicationError as e:
         raise e.to_http_exception() from e
     except Exception as e:

--- a/app/services/group_service.py
+++ b/app/services/group_service.py
@@ -189,13 +189,14 @@ class GroupService:
         self,
         group_id: uuid.UUID,
         member_user_id: uuid.UUID,
-        requesting_user_id: uuid.UUID,
     ) -> None:
         """Remove a member from a group if the requesting user is an admin."""
-        if requesting_user_id == member_user_id:
-            group = await self.group_repository.get_group_by_id(group_id)
-            if group and group.created_by == requesting_user_id:
-                raise GroupOwnerCannotLeaveError(requesting_user_id, group_id)
+        group = await self.group_repository.get_group_by_id(group_id)
+        if not group:
+            raise GroupNotFoundError(group_id)
+
+        if group.created_by == member_user_id:
+            raise GroupOwnerCannotLeaveError(member_user_id , group_id)
 
         is_removed = await self.group_member_repository.remove_member(member_user_id, group_id)
 


### PR DESCRIPTION
### Summary
Fixes a logic issue in group member removal where the group owner could be removed. Now correctly raises `GroupOwnerCannotLeaveError` if the owner is the target of removal.

### Changes
- Fixed the check to prevent the group owner from being removed
- Raised `GroupOwnerCannotLeaveError` when applicable

### Checklist
- [] Tests added/updated
- [ ] Documentation updated
